### PR TITLE
Support multiple entry points

### DIFF
--- a/packages/lwc-services/src/commands/build.ts
+++ b/packages/lwc-services/src/commands/build.ts
@@ -75,22 +75,20 @@ export default class Build extends Command {
         }
 
         log(messages.logs.creating_build_configuration)
-        let webpackConfig = generateWebpackConfig(flags.mode!)
 
-        log(messages.logs.build_start)
-
-        // Merging custom webpack config file
         if (flags.webpack) {
             log(messages.logs.custom_configuration)
-            const webpackConfigCustom = require(path.resolve(
+            var webpackConfigCustom = require(path.resolve(
                 process.cwd(),
                 flags.webpack
             ))
-            webpackConfig = webpackMerge.smart(
-                webpackConfig,
-                webpackConfigCustom
-            )
         }
+        let webpackConfig = generateWebpackConfig(
+            flags.mode!,
+            webpackConfigCustom
+        )
+
+        log(messages.logs.build_start)
 
         if (flags.mode && flags.mode !== lwcConfig.mode) {
             webpackConfig.mode = flags.mode

--- a/packages/lwc-services/src/config/webpack.config.ts
+++ b/packages/lwc-services/src/config/webpack.config.ts
@@ -3,7 +3,6 @@ const CopyPlugin = require('copy-webpack-plugin')
 const ErrorOverlayPlugin = require('error-overlay-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 // tslint:disable-next-line: no-implicit-dependencies
-import merge = require('deepmerge')
 import * as path from 'path'
 
 import { lwcConfig } from './lwcConfig'
@@ -14,12 +13,13 @@ const MODULE_DIR = path.resolve(ROOT_DIR, lwcConfig.moduleDir)
 const TEMPLATES_DIR = path.resolve(ROOT_DIR, lwcConfig.sourceDir)
 
 // Simple mechanism to pass any arbitrary config values from the CLI for webpack
-export function generateWebpackConfig(mode?: string, config?: any) {
+export function generateWebpackConfig(mode?: string, customConfig?: any) {
     let lwcWebpackConfig = buildWebpackConfig({
         entries: [path.resolve(TEMPLATES_DIR, 'index.js')],
         outputDir: OUTPUT_DIR,
         moduleDir: MODULE_DIR,
-        mode
+        mode,
+        customConfig
     })
 
     lwcWebpackConfig.plugins = (lwcWebpackConfig.plugins || []).concat([
@@ -27,10 +27,6 @@ export function generateWebpackConfig(mode?: string, config?: any) {
             template: path.resolve(TEMPLATES_DIR, 'index.html')
         })
     ])
-
-    if (config) {
-        lwcWebpackConfig = merge(lwcWebpackConfig, config)
-    }
 
     if (lwcConfig.resources.length) {
         let resources: any = []
@@ -44,8 +40,13 @@ export function generateWebpackConfig(mode?: string, config?: any) {
             new CopyPlugin(resources)
         ])
     }
-    lwcWebpackConfig.plugins = (lwcWebpackConfig.plugins || []).concat([
-        new ErrorOverlayPlugin()
-    ])
+
+    // error-overlay-webpack-plugin has a bug that breaks the build when > 1 entry point is specified
+    if (Object.keys(lwcWebpackConfig.entry).length == 1) {
+        lwcWebpackConfig.plugins = (lwcWebpackConfig.plugins || []).concat([
+            new ErrorOverlayPlugin()
+        ])
+    }
+
     return lwcWebpackConfig
 }

--- a/packages/lwc-services/src/utils/webpack/webpack-builder.ts
+++ b/packages/lwc-services/src/utils/webpack/webpack-builder.ts
@@ -34,10 +34,12 @@ const optimization: webpack.Options.Optimization = {
 }
 
 function isWebpackEntryFunc(entry: any): entry is webpack.EntryFunc {
-    return (typeof entry === 'function')
+    return typeof entry === 'function'
 }
 
-function getWebpackEntryPaths(entry: string | string[] | webpack.Entry): string[] {
+function getWebpackEntryPaths(
+    entry: string | string[] | webpack.Entry
+): string[] {
     if (typeof entry === 'string') {
         return [entry]
     }


### PR DESCRIPTION
In our project we have a use case where we would like to be able to specify multiple entry points in a custom Webpack configuration. (Allows us to specify a single component per .js file for a MPA).

Because the LWC module resolver only specifies the default `index.js` entry point when it is generated, any entry points specified in a custom config will not be able to resolve the component modules. These changes should resolve the modules after the custom config has been merged.

I thought this might be something worthwhile to have in the upstream.