### PR TITLE
Migrate tslint to eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,8 @@
 module.exports = {
     parser: '@typescript-eslint/parser',
-    
-    extends: [
-        'eslint:recommended',
-        'plugin:@typescript-eslint/recommended'
-    ],
-    
+
+    extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+
     parserOptions: {
         ecmaVersion: 2018,
         sourceType: 'module'
@@ -13,22 +10,23 @@ module.exports = {
 
     env: {
         node: true,
-        es6: true,
+        es6: true
     },
 
     rules: {
+        // TODO
+        '@typescript-eslint/no-var-requires': 0,
+
         // Using snakecase for log messages
         '@typescript-eslint/camelcase': 0,
 
-        // Conflicts with prettier config no semi
+        // Conflicts with prettier
+        '@typescript-eslint/indent': 0,
         '@typescript-eslint/member-delimiter-style': 0,
-
-        // TODO
-        '@typescript-eslint/no-var-requires': 0,
 
         // Rules with too much constraints
         '@typescript-eslint/explicit-member-accessibility': 0,
         '@typescript-eslint/explicit-function-return-type': 0,
-        '@typescript-eslint/no-explicit-any': 0,
+        '@typescript-eslint/no-explicit-any': 0
     }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,24 +1,34 @@
 module.exports = {
     parser: '@typescript-eslint/parser',
+    
     extends: [
-        'plugin:@typescript-eslint/recommended',
-        'prettier/@typescript-eslint',
-        'plugin:prettier/recommended'
+        'eslint:recommended',
+        'plugin:@typescript-eslint/recommended'
     ],
+    
     parserOptions: {
         ecmaVersion: 2018,
         sourceType: 'module'
     },
+
+    env: {
+        node: true,
+        es6: true,
+    },
+
     rules: {
-        'file-name-casing': [0, 'camel-case'],
-        'object-curly-spacing': 0,
+        // Using snakecase for log messages
         '@typescript-eslint/camelcase': 0,
+
+        // Conflicts with prettier config no semi
         '@typescript-eslint/member-delimiter-style': 0,
+
+        // TODO
         '@typescript-eslint/no-var-requires': 0,
+
+        // Rules with too much constraints
         '@typescript-eslint/explicit-member-accessibility': 0,
         '@typescript-eslint/explicit-function-return-type': 0,
         '@typescript-eslint/no-explicit-any': 0,
-        '@typescript-eslint/no-non-null-assertion': 0,
-        '@typescript-eslint/no-use-before-define': 0
     }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
         "lint-staged": "^8.1.6",
         "prettier": "^1.17.0",
         "ts-node": "^8",
-        "tslint-config-prettier": "^1.18.0",
         "typescript": "^3.3"
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
         "@typescript-eslint/eslint-plugin": "^1.8.0",
         "@typescript-eslint/parser": "^1.8.0",
         "eslint": "^5.16.0",
-        "eslint-config-prettier": "^4.3.0",
-        "eslint-plugin-prettier": "^3.1.0",
         "husky": "^2.2.0",
         "lerna": "^3.13.4",
         "lint-staged": "^8.1.6",

--- a/packages/lwc-create-app/package.json
+++ b/packages/lwc-create-app/package.json
@@ -21,11 +21,9 @@
         "yeoman-generator": "^4.0.0"
     },
     "devDependencies": {
-        "@oclif/tslint": "^3",
         "@types/node": "^10",
         "@types/semver-compare": "^1.0.0",
-        "ts-node": "^8",
-        "tslint": "^5"
+        "ts-node": "^8"
     },
     "engines": {
         "node": ">=10.0.0"
@@ -50,7 +48,6 @@
     },
     "repository": "muenzpraeger/lwc-create-app",
     "scripts": {
-        "posttest": "tslint -p . -t stylish",
         "build": "tsc -b"
     },
     "types": "lib/index.d.ts"

--- a/packages/lwc-create-app/src/generators/createGenerator.ts
+++ b/packages/lwc-create-app/src/generators/createGenerator.ts
@@ -1,6 +1,3 @@
-// tslint:disable no-floating-promises
-// tslint:disable no-console
-
 import { execSync, spawnSync } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'

--- a/packages/lwc-create-app/src/generators/createGenerator.ts
+++ b/packages/lwc-create-app/src/generators/createGenerator.ts
@@ -15,11 +15,16 @@ let hasYarn = false
 try {
     execSync('git --version', { stdio: 'ignore' })
     hasGit = true
-} catch {}
+} catch {
+    // Nothing
+}
+
 try {
     execSync('yarn -v', { stdio: 'ignore' })
     hasYarn = true
-} catch {}
+} catch {
+    // Nothing
+}
 
 class CreateGenerator extends Generator {
     options: {
@@ -257,7 +262,9 @@ class CreateGenerator extends Generator {
             try {
                 execSync('git init', { stdio: 'ignore' })
                 hasGit = true
-            } catch {}
+            } catch {
+                // Do nothing
+            }
         }
     }
 

--- a/packages/lwc-create-app/src/index.ts
+++ b/packages/lwc-create-app/src/index.ts
@@ -32,14 +32,12 @@ class Create extends Command {
             'CreateGenerator'
         )
 
-        // tslint:disable-next-line: no-console
         console.clear()
         welcome()
 
         await new Promise((resolve, reject) => {
             env.run(
                 'CreateGenerator',
-                // tslint:disable-next-line: object-literal-shorthand
                 { options: options, name: name },
                 (err: null | Error) => {
                     if (err) reject(err)

--- a/packages/lwc-services/package.json
+++ b/packages/lwc-services/package.json
@@ -47,7 +47,6 @@
     "devDependencies": {
         "@oclif/dev-cli": "^1",
         "@oclif/test": "^1",
-        "@oclif/tslint": "^3",
         "@types/chai": "^4",
         "@types/mocha": "^5",
         "@types/node": "^10",
@@ -55,8 +54,7 @@
         "@types/semver-compare": "^1.0.0",
         "@types/webpack": "^4.4.27",
         "@types/webpack-merge": "^4.1.4",
-        "cli-ux": "^5.2.1",
-        "tslint": "^5.16.0"
+        "cli-ux": "^5.2.1"
     },
     "engines": {
         "node": ">=10.0.0"
@@ -85,7 +83,6 @@
     },
     "repository": "muenzpraeger/lwc-create-app",
     "scripts": {
-        "posttest": "tslint -p test -t stylish",
         "build": "tsc -b",
         "genreadme": "oclif-dev readme && git add README.md"
     },

--- a/packages/lwc-services/src/commands/build.ts
+++ b/packages/lwc-services/src/commands/build.ts
@@ -11,34 +11,29 @@ import { log, welcome } from '../utils/logger'
 import { analyzeStats } from '../utils/webpack/statsAnalyzer'
 
 function buildWebpack(webpackConfig: any) {
-    return new Promise(
-        (resolve, reject): void => {
-            webpack(
-                webpackConfig,
-                (err: any, stats: any): void => {
-                    if (err) {
-                        reject(err)
-                    }
-                    if (!stats || !stats.compilation) {
-                        log(messages.errors.no_compilation)
-                    }
-                    // Parsing out error messages during compilation. Makes life MUCH easier.
-                    const { errors } = stats.compilation
-                    if (errors.length) {
-                        let errorMessages = ''
-                        errors.forEach((error: any) => {
-                            errorMessages = errorMessages
-                                .concat(error.message)
-                                .concat('\n')
-                        })
-                        return reject(errorMessages)
-                    }
-                    analyzeStats(stats)
-                    return resolve()
-                }
-            )
-        }
-    )
+    return new Promise((resolve, reject): void => {
+        webpack(webpackConfig, (err: any, stats: any): void => {
+            if (err) {
+                reject(err)
+            }
+            if (!stats || !stats.compilation) {
+                log(messages.errors.no_compilation)
+            }
+            // Parsing out error messages during compilation. Makes life MUCH easier.
+            const { errors } = stats.compilation
+            if (errors.length) {
+                let errorMessages = ''
+                errors.forEach((error: any) => {
+                    errorMessages = errorMessages
+                        .concat(error.message)
+                        .concat('\n')
+                })
+                return reject(errorMessages)
+            }
+            analyzeStats(stats)
+            return resolve()
+        })
+    })
 }
 
 export default class Build extends Command {

--- a/packages/lwc-services/src/commands/build.ts
+++ b/packages/lwc-services/src/commands/build.ts
@@ -42,7 +42,6 @@ export default class Build extends Command {
     async run() {
         const { flags } = this.parse(Build)
 
-        // tslint:disable-next-line: no-console
         console.clear()
         welcome()
 

--- a/packages/lwc-services/src/commands/build.ts
+++ b/packages/lwc-services/src/commands/build.ts
@@ -11,29 +11,34 @@ import { log, welcome } from '../utils/logger'
 import { analyzeStats } from '../utils/webpack/statsAnalyzer'
 
 function buildWebpack(webpackConfig: any) {
-    return new Promise((resolve, reject): void => {
-        webpack(webpackConfig, (err: any, stats: any): void => {
-            if (err) {
-                reject(err)
-            }
-            if (!stats || !stats.compilation) {
-                log(messages.errors.no_compilation)
-            }
-            // Parsing out error messages during compilation. Makes life MUCH easier.
-            const { errors } = stats.compilation
-            if (errors.length) {
-                let errorMessages = ''
-                errors.forEach((error: any) => {
-                    errorMessages = errorMessages
-                        .concat(error.message)
-                        .concat('\n')
-                })
-                return reject(errorMessages)
-            }
-            analyzeStats(stats)
-            return resolve()
-        })
-    })
+    return new Promise(
+        (resolve, reject): void => {
+            webpack(
+                webpackConfig,
+                (err: any, stats: any): void => {
+                    if (err) {
+                        reject(err)
+                    }
+                    if (!stats || !stats.compilation) {
+                        log(messages.errors.no_compilation)
+                    }
+                    // Parsing out error messages during compilation. Makes life MUCH easier.
+                    const { errors } = stats.compilation
+                    if (errors.length) {
+                        let errorMessages = ''
+                        errors.forEach((error: any) => {
+                            errorMessages = errorMessages
+                                .concat(error.message)
+                                .concat('\n')
+                        })
+                        return reject(errorMessages)
+                    }
+                    analyzeStats(stats)
+                    return resolve()
+                }
+            )
+        }
+    )
 }
 
 export default class Build extends Command {

--- a/packages/lwc-services/src/commands/build.ts
+++ b/packages/lwc-services/src/commands/build.ts
@@ -3,13 +3,38 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as rimraf from 'rimraf'
 import * as webpack from 'webpack'
-import * as webpackMerge from 'webpack-merge'
 
 import { lwcConfig } from '../config/lwcConfig'
 import { generateWebpackConfig } from '../config/webpack.config'
 import { messages } from '../messages/build'
 import { log, welcome } from '../utils/logger'
 import { analyzeStats } from '../utils/webpack/statsAnalyzer'
+
+function buildWebpack(webpackConfig: any) {
+    return new Promise((resolve, reject): void => {
+        webpack(webpackConfig, (err: any, stats: any): void => {
+            if (err) {
+                reject(err)
+            }
+            if (!stats || !stats.compilation) {
+                log(messages.errors.no_compilation)
+            }
+            // Parsing out error messages during compilation. Makes life MUCH easier.
+            const { errors } = stats.compilation
+            if (errors.length) {
+                let errorMessages = ''
+                errors.forEach((error: any) => {
+                    errorMessages = errorMessages
+                        .concat(error.message)
+                        .concat('\n')
+                })
+                return reject(errorMessages)
+            }
+            analyzeStats(stats)
+            return resolve()
+        })
+    })
+}
 
 export default class Build extends Command {
     static description = messages.description
@@ -42,6 +67,7 @@ export default class Build extends Command {
     async run() {
         const { flags } = this.parse(Build)
 
+        // eslint-disable-next-line no-console
         console.clear()
         welcome()
 
@@ -83,7 +109,7 @@ export default class Build extends Command {
             ))
         }
         let webpackConfig = generateWebpackConfig(
-            flags.mode!,
+            flags.mode,
             webpackConfigCustom
         )
 
@@ -101,36 +127,10 @@ export default class Build extends Command {
         }
 
         try {
-            await buildWebpack()
+            await buildWebpack(webpackConfig)
             log(messages.logs.build_end)
         } catch (error) {
             log({ message: error, emoji: 'sos' })
-        }
-
-        function buildWebpack() {
-            return new Promise((resolve, reject) => {
-                webpack(webpackConfig, (err: any, stats: any) => {
-                    if (err) {
-                        reject(err)
-                    }
-                    if (!stats || !stats.compilation) {
-                        log(messages.errors.no_compilation)
-                    }
-                    // Parsing out error messages during compilation. Makes life MUCH easier.
-                    const { errors } = stats.compilation
-                    if (errors.length) {
-                        let errorMessages = ''
-                        errors.forEach((error: any) => {
-                            errorMessages = errorMessages
-                                .concat(error.message)
-                                .concat('\n')
-                        })
-                        return reject(errorMessages)
-                    }
-                    analyzeStats(stats)
-                    return resolve()
-                })
-            })
         }
     }
 }

--- a/packages/lwc-services/src/commands/serve.ts
+++ b/packages/lwc-services/src/commands/serve.ts
@@ -3,10 +3,8 @@ import cli from 'cli-ux'
 import * as fs from 'fs'
 import * as path from 'path'
 
-// tslint:disable-next-line: no-implicit-dependencies
 const compression = require('compression')
 const helmet = require('helmet')
-// tslint:disable-next-line: no-implicit-dependencies
 const express = require('express')
 
 import { lwcConfig } from '../config/lwcConfig'
@@ -45,7 +43,6 @@ export default class Serve extends Command {
     async run() {
         const { flags } = this.parse(Serve)
 
-        // tslint:disable-next-line: no-console
         console.clear()
 
         welcome()
@@ -84,7 +81,6 @@ export default class Serve extends Command {
             customExpressConfig(app)
         }
 
-        // tslint:disable-next-line: no-unused
         app.use('*', (req: any, res: any) => {
             res.sendFile(path.resolve(BUILD_DIR, 'index.html'))
         })
@@ -95,7 +91,6 @@ export default class Serve extends Command {
             log(messages.logs.local_server_listening, url)
 
             if (flags.open) {
-                // tslint:disable-next-line: no-floating-promises
                 cli.open(url)
             }
         })

--- a/packages/lwc-services/src/commands/serve.ts
+++ b/packages/lwc-services/src/commands/serve.ts
@@ -43,8 +43,8 @@ export default class Serve extends Command {
     async run() {
         const { flags } = this.parse(Serve)
 
+        // eslint-disable-next-line no-console
         console.clear()
-
         welcome()
 
         const BUILD_DIR = flags.directory ? flags.directory : lwcConfig.buildDir

--- a/packages/lwc-services/src/commands/sniff.ts
+++ b/packages/lwc-services/src/commands/sniff.ts
@@ -31,8 +31,8 @@ export default class Sniff extends Command {
     async run() {
         const { flags } = this.parse(Sniff)
 
+        // eslint-disable-next-line no-console
         console.clear()
-
         welcome()
 
         if (!flags.directory) {

--- a/packages/lwc-services/src/commands/sniff.ts
+++ b/packages/lwc-services/src/commands/sniff.ts
@@ -1,5 +1,4 @@
 import { Command, flags } from '@oclif/command'
-// tslint:disable-next-line: no-implicit-dependencies
 import * as fs from 'fs'
 import * as path from 'path'
 import util = require('util')
@@ -32,7 +31,6 @@ export default class Sniff extends Command {
     async run() {
         const { flags } = this.parse(Sniff)
 
-        // tslint:disable-next-line: no-console
         console.clear()
 
         welcome()

--- a/packages/lwc-services/src/commands/test.ts
+++ b/packages/lwc-services/src/commands/test.ts
@@ -1,5 +1,4 @@
 import { Command, flags } from '@oclif/command'
-// tslint:disable-next-line: no-implicit-dependencies
 import merge = require('deepmerge')
 import * as fs from 'fs'
 import * as path from 'path'
@@ -32,7 +31,6 @@ export default class Test extends Command {
     async run() {
         const { flags } = this.parse(Test)
 
-        // tslint:disable-next-line: no-console
         console.clear()
 
         welcome()

--- a/packages/lwc-services/src/commands/test.ts
+++ b/packages/lwc-services/src/commands/test.ts
@@ -31,8 +31,8 @@ export default class Test extends Command {
     async run() {
         const { flags } = this.parse(Test)
 
+        // eslint-disable-next-line no-console
         console.clear()
-
         welcome()
 
         // Inspiration of this implementation taken from https://github.com/salesforce/lwc-jest. Thank you, Trevor!

--- a/packages/lwc-services/src/commands/watch.ts
+++ b/packages/lwc-services/src/commands/watch.ts
@@ -46,8 +46,8 @@ export default class Watch extends Command {
     async run() {
         const { flags } = this.parse(Watch)
 
+        // eslint-disable-next-line no-console
         console.clear()
-
         welcome()
 
         // Check if custom webpack config is passed, and if it really exists.
@@ -58,7 +58,7 @@ export default class Watch extends Command {
             }
         }
 
-        let webpackConfig = generateWebpackConfig(flags.mode!)
+        let webpackConfig = generateWebpackConfig(flags.mode)
         lwcConfig.devServer.contentBase = lwcConfig.sourceDir
         webpackConfig.devServer = lwcConfig.devServer
 

--- a/packages/lwc-services/src/commands/watch.ts
+++ b/packages/lwc-services/src/commands/watch.ts
@@ -46,7 +46,6 @@ export default class Watch extends Command {
     async run() {
         const { flags } = this.parse(Watch)
 
-        // tslint:disable-next-line: no-console
         console.clear()
 
         welcome()
@@ -88,7 +87,6 @@ export default class Watch extends Command {
         // Lazy loading
         const WebpackDevServer = require('webpack-dev-server')
 
-        // tslint:disable-next-line: no-unused
         const compiler = webpack(webpackConfig)
 
         const app = new WebpackDevServer(compiler, webpackConfig.devServer)
@@ -103,7 +101,6 @@ export default class Watch extends Command {
                 log(messages.logs.local_server_listening, url)
 
                 if (flags.open) {
-                    // tslint:disable-next-line: no-floating-promises
                     cli.open(url)
                 }
             }

--- a/packages/lwc-services/src/config/lwcConfig.ts
+++ b/packages/lwc-services/src/config/lwcConfig.ts
@@ -1,4 +1,3 @@
-// tslint:disable-next-line: no-implicit-dependencies
 import merge = require('deepmerge')
 import * as path from 'path'
 
@@ -108,7 +107,6 @@ function buildConfig(): Config {
         let config = require(fileName)
         combinedConfig = merge(defaultLwcConfig, config)
         return combinedConfig
-        // tslint:disable-next-line: no-unused
     } catch (error) {
         // We don't need error handling atm
     }

--- a/packages/lwc-services/src/config/webpack.config.ts
+++ b/packages/lwc-services/src/config/webpack.config.ts
@@ -2,7 +2,6 @@ const { buildWebpackConfig } = require('../utils/webpack/webpack-builder')
 const CopyPlugin = require('copy-webpack-plugin')
 const ErrorOverlayPlugin = require('error-overlay-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-// tslint:disable-next-line: no-implicit-dependencies
 import * as path from 'path'
 
 import { lwcConfig } from './lwcConfig'

--- a/packages/lwc-services/src/utils/resolver.ts
+++ b/packages/lwc-services/src/utils/resolver.ts
@@ -4,9 +4,11 @@ const lwcResolver = require('@lwc/jest-resolver')
 const { LAYOUT, isValidModuleName, getInfoFromId } = require('./webpack/module')
 import { lwcConfig } from '../config/lwcConfig'
 
-function getProjectInfo(layout: string): {
-    modulesDir: string;
-    namespaces: string;
+function getProjectInfo(
+    layout: string
+): {
+    modulesDir: string
+    namespaces: string
 } {
     const cwd = fs.realpathSync(process.cwd())
     const modulesDir = path.join(cwd + '', 'src', 'modules')
@@ -18,7 +20,7 @@ function getProjectInfo(layout: string): {
 }
 
 function isFile(file: string): boolean {
-    let result = false;
+    let result = false
 
     try {
         const stat = fs.statSync(file)
@@ -46,7 +48,6 @@ function resolveAsFile(name: string, extensions: string[]): string | null {
     }
     return null
 }
-
 
 module.exports = function(modulePath: string, options: any): string {
     const layout = lwcConfig.layout

--- a/packages/lwc-services/src/utils/resolver.ts
+++ b/packages/lwc-services/src/utils/resolver.ts
@@ -4,7 +4,51 @@ const lwcResolver = require('@lwc/jest-resolver')
 const { LAYOUT, isValidModuleName, getInfoFromId } = require('./webpack/module')
 import { lwcConfig } from '../config/lwcConfig'
 
-module.exports = function(modulePath: string, options: any) {
+function getProjectInfo(layout: string): {
+    modulesDir: string;
+    namespaces: string;
+} {
+    const cwd = fs.realpathSync(process.cwd())
+    const modulesDir = path.join(cwd + '', 'src', 'modules')
+    let namespaces = []
+    if (layout === LAYOUT.NAMESPACED) {
+        namespaces = fs.readdirSync(modulesDir)
+    }
+    return { modulesDir, namespaces }
+}
+
+function isFile(file: string): boolean {
+    let result = false;
+
+    try {
+        const stat = fs.statSync(file)
+        result = stat.isFile() || stat.isFIFO()
+    } catch (e) {
+        if (!(e && e.code === 'ENOENT')) {
+            throw e
+        }
+        result = false
+    }
+
+    return result
+}
+
+function resolveAsFile(name: string, extensions: string[]): string | null {
+    if (isFile(name)) {
+        return name
+    }
+
+    for (let extension of extensions) {
+        const file = name + extension
+        if (isFile(file)) {
+            return file
+        }
+    }
+    return null
+}
+
+
+module.exports = function(modulePath: string, options: any): string {
     const layout = lwcConfig.layout
     if (isValidModuleName(modulePath)) {
         const { modulesDir, namespaces } = getProjectInfo(layout)
@@ -27,41 +71,4 @@ module.exports = function(modulePath: string, options: any) {
         }
     }
     return lwcResolver.apply(null, arguments)
-}
-function getProjectInfo(layout: string) {
-    const cwd = fs.realpathSync(process.cwd())
-    const modulesDir = path.join(cwd + '', 'src', 'modules')
-    let namespaces = []
-    if (layout === LAYOUT.NAMESPACED) {
-        namespaces = fs.readdirSync(modulesDir)
-    }
-    return { modulesDir, namespaces }
-}
-function isFile(file: string) {
-    let result
-
-    try {
-        const stat = fs.statSync(file)
-        result = stat.isFile() || stat.isFIFO()
-    } catch (e) {
-        if (!(e && e.code === 'ENOENT')) {
-            throw e
-        }
-        result = false
-    }
-
-    return result
-}
-function resolveAsFile(name: string, extensions: string[]) {
-    if (isFile(name)) {
-        return name
-    }
-
-    for (let extension of extensions) {
-        const file = name + extension
-        if (isFile(file)) {
-            return file
-        }
-    }
-    return null
 }

--- a/packages/lwc-services/src/utils/webpack/module-loader.ts
+++ b/packages/lwc-services/src/utils/webpack/module-loader.ts
@@ -10,14 +10,12 @@ const { getConfig, getInfoFromPath } = require('./module')
 
 module.exports = function(source: any) {
     // @ts-ignore
-    // tslint:disable-next-line: no-this-assignment
     const { resourcePath } = this
 
     const config = getConfig(loaderUtils.getOptions(this))
     let info
     try {
         info = getInfoFromPath(resourcePath, config)
-        // tslint:disable-next-line: no-unused
     } catch (e) {
         info = {
             name: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11193,9 +11193,9 @@ tslib@^1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tsutils@^3.7.0:
-  version "3.10.0"
-  resolved "https://npmregistry-rw.herokuapp.com/tsutils/-/tsutils-3.10.0/6f1c95c94606e098592b0dff06590cf9659227d6.tgz#6f1c95c94606e098592b0dff06590cf9659227d6"
-  integrity sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.14.0.tgz#bf8d5a7bae5369331fa0f2b0a5a10bd7f7396c77"
+  integrity sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==
   dependencies:
     tslib "^1.8.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,25 +602,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@fimbul/bifrost@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.17.0.tgz#f0383ba7e40992e3193dc87e2ddfde2ad62a9cf4"
-  integrity sha512-gVTkJAOef5HtN6LPmrtt5fAUmBywwlgmObsU3FBhPoNeXPLaIl2zywXkJEtvvVLQnaFmtff3x+wIj5lHRCDE3Q==
-  dependencies:
-    "@fimbul/ymir" "^0.17.0"
-    get-caller-file "^2.0.0"
-    tslib "^1.8.1"
-    tsutils "^3.5.0"
-
-"@fimbul/ymir@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@fimbul/ymir/-/ymir-0.17.0.tgz#4f28389b9f804d1cd202e11983af1743488b7815"
-  integrity sha512-xMXM9KTXRLHLVS6dnX1JhHNEkmWHcAVCQ/4+DA1KKwC/AFnGHzu/7QfQttEPgw3xplT+ILf9e3i64jrFwB3JtA==
-  dependencies:
-    inversify "^5.0.0"
-    reflect-metadata "^0.1.12"
-    tslib "^1.8.1"
-
 "@jest/console@^24.7.1":
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
@@ -1692,14 +1673,6 @@
   integrity sha512-c0khMdYBGV7t9L7SNbh84t9PmTqfaTp4Jqf3JbWu80fd+SAM03m9o+dvrgx+qv4YbSTum4GpXBZtXHq4AXsD3Q==
   dependencies:
     fancy-test "^1.4.3"
-
-"@oclif/tslint@^3":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@oclif/tslint/-/tslint-3.1.1.tgz#e055cdf158630862fd44546f6b8fb1266c9778e7"
-  integrity sha512-B1ZWbgzwxDhNZLzVnn+JjyFf9u+J9wNwsz/ZX9YvA9edRYcdiJz9JikCttGPi35V0NU0TUV4UqTqo/q/wQ06jQ==
-  dependencies:
-    tslint-eslint-rules "^5.4.0"
-    tslint-xo "^0.9.0"
 
 "@octokit/endpoint@^5.1.0":
   version "5.1.4"
@@ -3016,11 +2989,6 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
-
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -3210,7 +3178,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3555,7 +3523,7 @@ commander@2.17.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^2.12.1, commander@^2.14.1, commander@^2.19.0, commander@^2.9.0, commander@~2.20.0:
+commander@^2.14.1, commander@^2.19.0, commander@^2.9.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -4273,7 +4241,7 @@ diff-sequences@^24.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
-diff@^3.2.0, diff@^3.5.0:
+diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -4331,14 +4299,6 @@ dns-txt@^2.0.2:
   integrity sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
   dependencies:
     buffer-indexof "^1.0.0"
-
-doctrine@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-0.7.2.tgz#7cb860359ba3be90e040b26b729ce4bfa654c523"
-  integrity sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=
-  dependencies:
-    esutils "^1.1.6"
-    isarray "0.0.1"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -4822,11 +4782,6 @@ estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
-
-esutils@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.1.6.tgz#c01ccaa9ae4b897c6d0c3e210ae52f3c7a844375"
-  integrity sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -5397,11 +5352,6 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
-
-get-caller-file@^2.0.0:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
-  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.0"
@@ -6247,11 +6197,6 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-inversify@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.1.tgz#500d709b1434896ce5a0d58915c4a4210e34fb6e"
-  integrity sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==
-
 invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
@@ -6596,11 +6541,6 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -9885,11 +9825,6 @@ referrer-policy@1.2.0:
   resolved "https://registry.yarnpkg.com/referrer-policy/-/referrer-policy-1.2.0.tgz#b99cfb8b57090dc454895ef897a4cc35ef67a98e"
   integrity sha512-LgQJIuS6nAy1Jd88DCQRemyE3mS+ispwlqMk3b0yjZ257fI1v9c+/p6SD5gP5FGyXUIgrNOAfmyioHwZtYv2VA==
 
-reflect-metadata@^0.1.12:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
-  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
-
 regenerate-unicode-properties@^8.0.2:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"
@@ -11283,92 +11218,15 @@ ts-node@^8:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-tslib@1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
-  integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
-
-tslib@^1, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslint-config-prettier@^1.18.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
-  integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
-
-tslint-consistent-codestyle@^1.11.0:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.15.1.tgz#a0c5cd5a5860d40b659c490d8013c5732e02af8c"
-  integrity sha512-38Y3Dz4zcABe/PlPAQSGNEWPGVq0OzcIQR7SEU6dNujp/SgvhxhJOhIhI9gY4r0I3/TNtvVQwARWor9O9LPZWg==
-  dependencies:
-    "@fimbul/bifrost" "^0.17.0"
-    tslib "^1.7.1"
-    tsutils "^2.29.0"
-
-tslint-eslint-rules@^5.3.1, tslint-eslint-rules@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz#e488cc9181bf193fe5cd7bfca213a7695f1737b5"
-  integrity sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==
-  dependencies:
-    doctrine "0.7.2"
-    tslib "1.9.0"
-    tsutils "^3.0.0"
-
-tslint-microsoft-contrib@^5.0.2:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
-  integrity sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
-  dependencies:
-    tsutils "^2.27.2 <2.29.0"
-
-tslint-xo@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/tslint-xo/-/tslint-xo-0.9.0.tgz#e1faa505fecd5ac705460fc9f5ca417c3036c14f"
-  integrity sha512-Zk5jBdQVUaHEmR9TUoh1TJOjjCr7/nRplA+jDZBvucyBMx65pt0unTr6H/0HvrtSlucFvOMYsyBZE1W8b4AOig==
-  dependencies:
-    tslint-consistent-codestyle "^1.11.0"
-    tslint-eslint-rules "^5.3.1"
-    tslint-microsoft-contrib "^5.0.2"
-
-tslint@^5, tslint@^5.16.0:
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.17.0.tgz#f9f0ce2011d8e90debaa6e9b4975f24cd16852b8"
-  integrity sha512-pflx87WfVoYepTet3xLfDOLDm9Jqi61UXIKePOuca0qoAZyrGWonDG9VTbji58Fy+8gciUn8Bt7y69+KEVjc/w==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    builtin-modules "^1.1.1"
-    chalk "^2.3.0"
-    commander "^2.12.1"
-    diff "^3.2.0"
-    glob "^7.1.1"
-    js-yaml "^3.13.1"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tslib "^1.8.0"
-    tsutils "^2.29.0"
-
-"tsutils@^2.27.2 <2.29.0":
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.28.0.tgz#6bd71e160828f9d019b6f4e844742228f85169a1"
-  integrity sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
-  dependencies:
-    tslib "^1.8.1"
-
-tsutils@^2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
-  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  dependencies:
-    tslib "^1.8.1"
-
-tsutils@^3.0.0, tsutils@^3.5.0, tsutils@^3.7.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.14.0.tgz#bf8d5a7bae5369331fa0f2b0a5a10bd7f7396c77"
-  integrity sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==
+tsutils@^3.7.0:
+  version "3.10.0"
+  resolved "https://npmregistry-rw.herokuapp.com/tsutils/-/tsutils-3.10.0/6f1c95c94606e098592b0dff06590cf9659227d6.tgz#6f1c95c94606e098592b0dff06590cf9659227d6"
+  integrity sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==
   dependencies:
     tslib "^1.8.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4605,13 +4605,6 @@ escodegen@^1.11.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz#c55c1fcac8ce4518aeb77906984e134d9eb5a4f0"
-  integrity sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==
-  dependencies:
-    get-stdin "^6.0.0"
-
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
@@ -4649,13 +4642,6 @@ eslint-plugin-jest@^22.0.0:
   version "22.6.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.6.4.tgz#2895b047dd82f90f43a58a25cf136220a21c9104"
   integrity sha512-36OqnZR/uMCDxXGmTsqU4RwllR0IiB/XF8GW3ODmhsjiITKuI0GpgultWFt193ipN3HARkaIcKowpE6HBvRHNg==
-
-eslint-plugin-prettier@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
-  integrity sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
 
 eslint-scope@3.7.1:
   version "3.7.1"
@@ -5002,11 +4988,6 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.0.2, fast-glob@^2.2.6, fast-glob@~2.2.6:
   version "2.2.7"
@@ -5378,11 +5359,6 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
-
-get-stdin@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
-  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stdin@^7.0.0:
   version "7.0.0"
@@ -9265,13 +9241,6 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier@^1.17.0, prettier@^1.17.1:
   version "1.18.0"


### PR DESCRIPTION
## Changes

This PR is the first iteration to fix #21.

* Remove all the tslint occurrences in the code base
* Remove prettier eslint configuration
* Enable `eslint:recommended` config to catch some trivial code issues
* Fix some of the existing rule issues: `no-non-null-assertion` and `no-use-before-define`.

IMO, having eslint-prettier + prettier running on the same code base is unnecessary. The main purpose of prettier is to free developers mind from formatting their code and let the tool do it. While eslint-prettier logs errors when the code is not formatted as prettier expects it. Since we already have commit hooks in place in this repo to auto format the code, there is no need to log errors when the code match the expected format.

While `explicit-member-accessibility`, `explicit-function-return-type` and `no-explicit-any` are really strict rules and would require a lot of work to make them pass, `no-var-requires` is the next linting rule to tackle. It would make the code more consistent and would also force us to better type the modules.