### PR TITLE
createGenerator require statement bug fix

### DIFF
--- a/packages/lwc-create-app/src/index.ts
+++ b/packages/lwc-create-app/src/index.ts
@@ -28,7 +28,7 @@ class Create extends Command {
         const env = createEnv()
 
         env.register(
-            require.resolve('./generators/CreateGenerator'),
+            require.resolve('./generators/createGenerator'),
             'CreateGenerator'
         )
 


### PR DESCRIPTION
index.ts required create generator function as CreateGenerator instead of ./generators/createGenerator (camel case). This was throwing errors in linux system as couldn't resolve the required dep. 