### PR TITLE
local proxy in example

### DIFF
--- a/packages/lwc-services/example/lwc-services.config.js
+++ b/packages/lwc-services/example/lwc-services.config.js
@@ -19,7 +19,7 @@ module.exports = {
     sourceDir: './src/client',
     // List of resources for copying to the build folder
     resources: [{ from: 'src/resources', to: 'dist/resources' }],
-    // Default server options for watch command
+    // Default server options for watch command.  See more options at https://webpack.js.org/configuration/dev-server
     devServer: {
         port: 3001,
         host: '0.0.0.0',
@@ -27,6 +27,8 @@ module.exports = {
         stats: 'errors-only',
         noInfo: true,
         contentBase: './src/client'
+        // run a local backend on another port (ex: nodejs) but still use watch command for lwc live re-loading
+        // proxy: { '/': 'http://localhost:8443'},
     },
     // Default server options for serve command
     server: {


### PR DESCRIPTION
Very common scenario: you wrote a backend that's non-trivial, and want to use LWC as the front-end.  

You love the live-reload of lwc-services watch, but want to use your real backend.  Added the example of local proxy and a link to all the webpack devserver options.